### PR TITLE
faster LIST operations

### DIFF
--- a/src/main/scala/Data.scala
+++ b/src/main/scala/Data.scala
@@ -229,7 +229,7 @@ class ListNode extends Node[mutable.ArrayBuffer[String]] {
     case "RPUSH"      => value ++= args; run("LLEN")
     case "LPUSHX"     => run("LPUSH")
     case "RPUSHX"     => run("RPUSH")
-    case "LPOP"       => val x = value(0); value -= x; x
+    case "LPOP"       => value remove 0
     case "RPOP"       => val x = value.last; value.reduceToSize(value.size - 1); x
     case "LSET"       => value(args(0).toInt) = args(1); SimpleReply()
     case "LINDEX"     => val x = args(0).toInt; if (x >= 0 && x < value.size) value(x) else null


### PR DESCRIPTION
This should be a faster LPOP, -= first run indexOf then remove, just remove is enough.

Redis list is like a linked list, so use ListBuffer instead of ArrayBuffer could be a improvement.

Before:

```
PING_INLINE: 80906.16 requests per second
PING_BULK: 92936.80 requests per second
SET: 72463.77 requests per second
GET: 74349.44 requests per second
INCR: 76452.60 requests per second
LPUSH: 3743.22 requests per second
LPOP: 3724.39 requests per second
SADD: 64143.68 requests per second
SPOP: 74682.60 requests per second
LPUSH (needed to benchmark LRANGE): 4025.60 requests per second
LRANGE_100 (first 100 elements): 23501.76 requests per second
LRANGE_300 (first 300 elements): 12115.34 requests per second
LRANGE_500 (first 450 elements): 10577.53 requests per second
LRANGE_600 (first 600 elements): 6588.48 requests per second
MSET (10 keys): 16160.31 requests per second
```

After:

```
PING_INLINE: 39093.04 requests per second
PING_BULK: 63775.51 requests per second
SET: 47961.63 requests per second
GET: 69783.67 requests per second
INCR: 66844.91 requests per second
LPUSH: 61919.50 requests per second
LPOP: 66755.67 requests per second
SADD: 69979.01 requests per second
SPOP: 75244.55 requests per second
LPUSH (needed to benchmark LRANGE): 63091.48 requests per second
LRANGE_100 (first 100 elements): 32851.51 requests per second
LRANGE_300 (first 300 elements): 17214.67 requests per second
LRANGE_500 (first 450 elements): 12843.57 requests per second
LRANGE_600 (first 600 elements): 10126.58 requests per second
MSET (10 keys): 19876.76 requests per second
```
