### PR TITLE
fix set aggregation operations when some key does not exist

### DIFF
--- a/src/main/resources/commands.conf
+++ b/src/main/resources/commands.conf
@@ -68,7 +68,7 @@ commands {
     SADD         = {args: 1-many, writes: true}
     SCARD        = {default: zero}
     SISMEMBER    = {args: 1, default: zero}
-    SMEMBERS     = {default: seq}
+    SMEMBERS     = {default: set}
     SMOVE        = {args: 2, default: error, writes: true}
     SPOP         = {default: nil, writes: true}
     SRANDMEMBER  = {args: 0-1, default: nil}

--- a/src/main/resources/commands.conf
+++ b/src/main/resources/commands.conf
@@ -54,7 +54,7 @@ commands {
     LRANGE       = {args: 2, default: seq}
     LREM         = {args: 2, default: zero, writes: true}
     LSET         = {args: 2, default: error, writes: true}
-    LTRIM        = {args: 2, default: ok}
+    LTRIM        = {args: 2, default: ok, writes: true}
     RPOP         = {default: nil, writes: true}
     RPOPLPUSH    = {args: 1, default: nil, writes: true}
     RPUSH        = {args: 1-many, writes: true}

--- a/src/main/resources/commands.conf
+++ b/src/main/resources/commands.conf
@@ -52,7 +52,7 @@ commands {
     LPUSH        = {args: 1-many, writes: true}
     LPUSHX       = {args: 1, default: zero, writes: true}
     LRANGE       = {args: 2, default: seq}
-    LREM         = {args: 2, default: zero}
+    LREM         = {args: 2, default: zero, writes: true}
     LSET         = {args: 2, default: error, writes: true}
     LTRIM        = {args: 2, default: ok}
     RPOP         = {default: nil, writes: true}
@@ -105,7 +105,7 @@ commands {
   bitmap {
     _RENAME      = {args: 1}
     _BSTORE      = {args: 0-many, overwrites: true}
-    _BGET        = {default: seq}
+    _BGET        = {default: bitset}
     SETBIT       = {args: 2, writes: true}
     BITCOUNT     = {args: 0-2, default: zero}
     BITPOS       = {args: 1-3}

--- a/src/main/scala/Aggregation.scala
+++ b/src/main/scala/Aggregation.scala
@@ -274,9 +274,8 @@ class AggregateBitOp extends Aggregate[mutable.BitSet]("_BGET") {
       case "OR"  => ordered.reduce(_ | _)
       case "XOR" => ordered.reduce(_ ^ _)
       case "NOT" =>
-        val from = ordered(0).headOption.getOrElse(1) - 1
-        val to = ordered(0).lastOption.getOrElse(1) - 1
-        mutable.BitSet(from until to: _*) ^ ordered(0)
+        val end = ordered(0).lastOption.getOrElse(-1)
+        mutable.BitSet(0 to end: _*) ^ ordered(0)
     }
     route(Seq("_BSTORE", args(1)) ++ result, destination = command.destination)
   }

--- a/src/main/scala/Commands.scala
+++ b/src/main/scala/Commands.scala
@@ -104,6 +104,7 @@ object Commands {
       case "neg1"   => -1
       case "neg2"   => -2
       case "seq"    => Seq()
+      case "set"    => mutable.Set()
       case "SCAN"   => Seq("0", "")
       case "nils"   => args.map(_ => null)
       case "zeros"  => args.map(_ => 0)

--- a/src/main/scala/Commands.scala
+++ b/src/main/scala/Commands.scala
@@ -105,6 +105,7 @@ object Commands {
       case "neg2"   => -2
       case "seq"    => Seq()
       case "set"    => mutable.Set()
+      case "bitset" => mutable.BitSet()
       case "SCAN"   => Seq("0", "")
       case "nils"   => args.map(_ => null)
       case "zeros"  => args.map(_ => 0)

--- a/src/main/scala/Data.scala
+++ b/src/main/scala/Data.scala
@@ -386,7 +386,7 @@ class SortedSetNode extends Node[(IndexedTreeMap[String, Float], IndexedTreeSet[
    */
   def rank(key: String, reverse: Boolean = false): Int = {
     val index = scores.entryIndex(SortedSetEntry(keys.get(key), key))
-    if (reverse) keys.size - index else index
+    if (reverse) keys.size - index - 1 else index
   }
 
   /**
@@ -425,7 +425,7 @@ class SortedSetNode extends Node[(IndexedTreeMap[String, Float], IndexedTreeSet[
     def parse(arg: String, dir: Float) = arg match {
       case "-inf" => if (scores.isEmpty) 0 else scores.first().score
       case "+inf" => if (scores.isEmpty) 0 else scores.last().score
-      case arg if arg.startsWith("(") => arg.toFloat + dir
+      case arg if arg.startsWith("(") => arg.tail.toFloat + dir
       case _ => arg.toFloat
     }
     range(SortedSetEntry(parse(from, 1)), SortedSetEntry(parse(to, -1) + 1), reverse)

--- a/src/main/scala/Data.scala
+++ b/src/main/scala/Data.scala
@@ -147,7 +147,7 @@ class HashNode extends Node[mutable.Map[String, String]] {
     case "HVALS"        => value.values
     case "HDEL"         => val x = run("HEXISTS"); value -= args(0); x
     case "HLEN"         => value.size
-    case "HMGET"        => args.map(value.get(_))
+    case "HMGET"        => args.map(value.getOrElse(_, null))
     case "HMSET"        => argsPaired.foreach {args => value(args._1) = args._2}; SimpleReply()
     case "HINCRBY"      => set(value.getOrElse(args(0), "0").toInt + args(1).toInt).toInt
     case "HINCRBYFLOAT" => set(value.getOrElse(args(0), "0").toFloat + args(1).toFloat)

--- a/src/main/scala/Data.scala
+++ b/src/main/scala/Data.scala
@@ -226,8 +226,8 @@ class ListNode extends Node[mutable.ListBuffer[String]] {
    * item for the given count, in either direction in linear time.
    */
   def remove: Int = {
-    val item = args(0)
-    val count = args(1).toInt
+    val count = args(0).toInt
+      val item = args(1)
     var result = 0
     val iter = if (count >= 0) value.clone.iterator else value.clone.reverseIterator
     value.clear

--- a/src/main/scala/PubSub.scala
+++ b/src/main/scala/PubSub.scala
@@ -49,7 +49,7 @@ trait PubSubServer extends CommandProcessing {
    * ClientNode when a change in subscription occurs.
    */
   def subscribeOrUnsubscribe: Unit = {
-    val pattern = command.name.startsWith("_p")
+    val pattern = command.name.startsWith("_P")
     val subscriptions = if (pattern) patterns else channels
     val key = if (pattern) args(0) else command.key
     val subscriber = command.destination.get
@@ -116,7 +116,7 @@ trait PubSubClient extends CommandProcessing {
    * namely SUBSCRIBE/UNSUBSCRIBE/PSUBSCRIBE/PUNSUBSCRIBE.
    */
   def subscribeOrUnsubscribe: Unit = {
-    val pattern = command.name.head == 'p'
+    val pattern = command.name.head == 'P'
     val subscribed = if (pattern) patterns else channels
     val xs = if (args.isEmpty) subscribed.toSeq else args
     xs.foreach {x => route(Seq("_" + command.name, x), destination = command.destination, broadcast = pattern)}
@@ -160,8 +160,8 @@ trait PubSubClient extends CommandProcessing {
    */
   def receivePubSub: Receive = {
     case PubSubEvent(event, channelOrPattern) =>
-      val subscriptions = if (event.head == 'p') patterns else channels
-      val subscribing = event.stripPrefix("p") == "SUBSCRIBE"
+      val subscriptions = if (event.head == 'P') patterns else channels
+      val subscribing = event.stripPrefix("P") == "SUBSCRIBE"
       val subscribed = subscribing && subscriptions.add(channelOrPattern)
       val unsubscribed = !subscribing && subscriptions.remove(channelOrPattern)
       if (subscribed || unsubscribed) {

--- a/src/main/scala/System.scala
+++ b/src/main/scala/System.scala
@@ -463,7 +463,7 @@ class KeyNode extends Node[mutable.Map[String, mutable.Map[String, NodeEntry]]] 
     case "_FLUSHDB"      => db.keys.map(key => delete(key)); SimpleReply()
     case "_FLUSHALL"     => value.foreach(db => db._2.keys.map(key => delete(key, Some(db._1)))); SimpleReply()
     case "EXISTS"        => args.map(db.contains)
-    case "TTL"           => ttl / 1000
+    case "TTL"           => val t = ttl; if(t == -1) t else t / 1000
     case "PTTL"          => ttl
     case "EXPIRE"        => expire(System.currentTimeMillis + (args(0).toInt * 1000))
     case "PEXPIRE"       => expire(System.currentTimeMillis + args(0).toInt)


### PR DESCRIPTION
When using set aggregation operations, if some key does not exists. curiodb return ErrorReply.
but in redis, it ignores the empty.
here is the test:
127.0.0.1:6379> keys *
1) "website2"
2) "website1"
127.0.0.1:6379> smembers website1
1) "google.com"
2) "baidu.com"
127.0.0.1:6379> sunion website1 website3
"ErrorReply"

The reason is in commands.conf, default value of set is seq, when convert to mutable.set is nil.
after change:
127.0.0.1:6379> sunion website1 website3
1) "google.com"
2) "baidu.com"
